### PR TITLE
Add vacation-mode pause/resume for scheduled bugle plays

### DIFF
--- a/schedule_sonos.py
+++ b/schedule_sonos.py
@@ -35,6 +35,7 @@ unit so that ``sonos_play.py`` receives it at runtime.
 """
 
 import glob as _glob
+import json
 import logging
 import os
 import re
@@ -42,13 +43,13 @@ import shlex
 import subprocess
 import sys
 import tempfile
-from datetime import datetime, time, timedelta
+from datetime import date, datetime, time, timedelta
 
 from astral import LocationInfo
 from astral.sun import sun
 import pytz
 
-from config import load_config, INSTALL_DIR, LOG_FILE  # noqa: F401 (LOG_FILE triggers basicConfig)
+from config import CONFIG_PATH, load_config, INSTALL_DIR, LOG_FILE  # noqa: F401 (LOG_FILE triggers basicConfig)
 
 _log = logging.getLogger("schedule_sonos")
 
@@ -753,6 +754,151 @@ def _clean_stale_units(current_names):
 
 
 # ---------------------------------------------------------------------------
+# Pause / vacation-mode helpers
+# ---------------------------------------------------------------------------
+
+def _clear_pause_in_config(config_path: str) -> bool:
+    """
+    Clear ``paused`` / ``paused_until`` in config.json for auto-resume.
+
+    Used by :func:`_resolve_pause_state` when the configured ``paused_until``
+    date has elapsed (the morning after the last paused day).  Performs an
+    atomic rewrite that preserves all other config keys and the file's
+    original ownership/permissions so the user account that originally wrote
+    config.json can still rewrite it from setup.sh.
+
+    Args:
+        config_path (str): Absolute path to config.json.
+
+    Returns:
+        bool: ``True`` if the file was rewritten, ``False`` on any failure
+        (the caller logs and proceeds — auto-resume is best-effort).
+    """
+    try:
+        with open(config_path) as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        _log.warning("Auto-resume: could not read %s: %s", config_path, exc)
+        return False
+    cfg["paused"] = False
+    cfg["paused_until"] = ""
+    try:
+        st = os.stat(config_path)
+        dir_path = os.path.dirname(config_path) or "."
+        fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(cfg, f, indent=2)
+                f.write("\n")
+            os.chmod(tmp_path, st.st_mode & 0o7777)
+            if hasattr(os, "chown"):
+                try:
+                    os.chown(tmp_path, st.st_uid, st.st_gid)
+                except (OSError, PermissionError):
+                    # Non-root or unsupported FS — keep going; mv-replace still works
+                    pass
+            os.replace(tmp_path, config_path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except OSError as exc:
+        _log.warning("Auto-resume: could not rewrite %s: %s", config_path, exc)
+        return False
+    return True
+
+
+def _resolve_pause_state(config: dict):
+    """
+    Resolve config-level pause state, applying auto-resume when due.
+
+    A pause expires the morning after ``paused_until``.  When this script runs
+    on or after ``paused_until + 1 day``, ``paused`` and ``paused_until`` are
+    cleared in config.json (in place) and the live *config* dict is updated so
+    the rest of ``main()`` proceeds as if the pause had never been set.
+
+    Args:
+        config (dict): Mutable configuration dictionary loaded by
+            :func:`config.load_config`.  Cleared in place on auto-resume.
+
+    Returns:
+        tuple[bool, str]: ``(is_paused, status_msg)``.  ``status_msg`` is a
+        short human-readable description used for log/print output.  When
+        ``is_paused`` is False, ``status_msg`` may still contain a one-line
+        note about an auto-resume that just occurred.
+    """
+    paused = bool(config.get("paused", False))
+    until_raw = (config.get("paused_until") or "").strip()
+    if not paused:
+        return False, ""
+
+    if until_raw:
+        try:
+            until_date = datetime.strptime(until_raw, "%Y-%m-%d").date()
+        except ValueError:
+            _log.warning(
+                "Invalid paused_until %r in config.json — treating as indefinite pause",
+                until_raw,
+            )
+            return True, "Paused indefinitely (paused_until unparseable)"
+        today = date.today()
+        if today > until_date:
+            # paused_until has elapsed — auto-resume.
+            if _clear_pause_in_config(CONFIG_PATH):
+                config["paused"] = False
+                config["paused_until"] = ""
+                msg = (
+                    f"Auto-resumed: paused_until {until_raw} elapsed "
+                    f"(today is {today.isoformat()})"
+                )
+                _log.info(msg)
+                print(f"  ▶️  {msg}")
+                return False, msg
+            # Could not rewrite config.json — keep treating as paused so we
+            # don't accidentally re-enable timers when the user has not been
+            # informed.  Next reschedule run will retry.
+            return True, (
+                f"Paused (auto-resume due {until_raw}, but config.json rewrite failed)"
+            )
+        resume_on = (until_date + timedelta(days=1)).isoformat()
+        return True, f"Paused (resumes {resume_on})"
+    return True, "Paused indefinitely"
+
+
+def _disable_active_schedule_timers():
+    """
+    Disable + stop any currently-enabled ``flag-{name}.timer`` schedule units.
+
+    Called when entering pause mode so timers that were previously enabled by
+    a first-install run don't continue firing.  Reserved units
+    (``flag-audio-http``, ``flag-reschedule``, ``flag-boot-reschedule``) are
+    intentionally left alone — the daily reschedule timer must keep running so
+    we can re-evaluate ``paused_until`` and auto-resume.
+
+    Returns:
+        list[str]: Names of timer units that were actually disabled (used for
+        log/print output).
+    """
+    disabled = []
+    for unit_path in _glob.glob(os.path.join(SYSTEMD_DIR, "flag-*.timer")):
+        unit = os.path.basename(unit_path)
+        inner = unit[len("flag-"):-len(".timer")]
+        if inner in _RESERVED_NAMES:
+            continue
+        if not _is_timer_enabled(unit):
+            continue
+        try:
+            _run_systemctl("disable", "--now", unit)
+            disabled.append(unit)
+            _log.info("Pause: disabled %s", unit)
+        except RuntimeError as exc:
+            _log.warning("Pause: could not disable %s: %s", unit, exc)
+    return disabled
+
+
+# ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
 
@@ -822,6 +968,14 @@ def main():
     tz_name = config["timezone"]
 
     _log.info("schedule_sonos.py started (timezone=%s)", tz_name)
+
+    # Resolve pause state up front.  If paused_until has elapsed, this clears
+    # the flag in config.json (auto-resume) and returns is_paused=False so the
+    # rest of main() activates timers normally.
+    is_paused, pause_msg = _resolve_pause_state(config)
+    if is_paused:
+        _log.info("Pause mode: %s", pause_msg)
+        print(f"  ⏸️  {pause_msg}")
 
     schedules = resolve_schedules(config)
     if not schedules:
@@ -1070,6 +1224,46 @@ def main():
         _log.info("Skipping daemon-reload: no unit files changed and no stale units removed")
 
     # --- Activate timers ---
+    if is_paused:
+        # Vacation mode: unit files are written/refreshed normally so a future
+        # resume just needs to enable --now them, but no schedule timer is
+        # allowed to fire while paused.  The reschedule timer (and the boot
+        # reschedule service) stay enabled so the daily 02:00 run can detect
+        # paused_until elapsing and auto-resume.
+        disabled = _disable_active_schedule_timers()
+        if disabled:
+            for unit in disabled:
+                print(f"  ⏸️  Disabled (paused): {unit}")
+        else:
+            print("  ⏸️  No active schedule timers to disable.")
+        # Make sure the reschedule timer itself is enabled so the next 02:00
+        # run can re-evaluate paused_until.
+        if not _is_timer_enabled("flag-reschedule.timer"):
+            try:
+                _run_systemctl("enable", "--now", "flag-reschedule.timer")
+                print("  ✅ Enabled (for daily resume check): flag-reschedule.timer")
+            except RuntimeError as exc:
+                print(f"  ⚠️  Could not enable flag-reschedule.timer: {exc}")
+                _log.error("Could not enable flag-reschedule.timer: %s", exc)
+        # Same for the boot-reschedule oneshot — without it, a reboot during
+        # a multi-week pause would leave the resume check unarmed until the
+        # next 02:00.
+        try:
+            _run_systemctl("enable", "flag-boot-reschedule.service")
+        except RuntimeError as exc:
+            _log.warning(
+                "Could not enable flag-boot-reschedule.service while paused: %s", exc
+            )
+
+        print("")
+        print(f"  ⏸️  Paused — no scheduled plays will fire. {pause_msg}")
+        print("  To resume: ./setup.sh → option 10) Resume scheduled plays")
+        print("")
+        print("To verify (timers should be inactive):")
+        print("  systemctl list-timers --all | grep flag")
+        _log.info("schedule_sonos.py completed (paused mode)")
+        return
+
     if is_reschedule:
         # Reschedule run: restart fixed-time timers only when their unit file
         # actually changed.  Skipping the restart when content is unchanged

--- a/setup.sh
+++ b/setup.sh
@@ -20,8 +20,9 @@ readonly MENU_UPGRADE=6
 readonly MENU_RECONFIG=7
 readonly MENU_RELOAD=8
 readonly MENU_MANAGE=9
-readonly MENU_UNINSTALL=10
-readonly MENU_EXIT=11
+readonly MENU_PAUSE=10
+readonly MENU_UNINSTALL=11
+readonly MENU_EXIT=12
 
 # ---------------------------------------------------------------------------
 # Table of contents
@@ -716,6 +717,12 @@ function configure_setup() {
             '. + [{"name": $name, "audio_url": $url, "time": $time}]')
     done
 
+    # Preserve any existing pause state across reconfigure so a vacation pause
+    # is not silently lost when the user re-runs option 7.
+    PAUSED_PRESERVED=$(cfg_default "paused" "false")
+    [[ "$PAUSED_PRESERVED" != "true" && "$PAUSED_PRESERVED" != "false" ]] && PAUSED_PRESERVED="false"
+    PAUSED_UNTIL_PRESERVED=$(cfg_default "paused_until" "")
+
     # Write the complete config.json using jq for correct JSON encoding
     echo ""
     echo "  Writing config to $CONFIG_FILE ..."
@@ -723,13 +730,15 @@ function configure_setup() {
         --argjson  speakers        "$SPEAKERS_JSON" \
         --argjson  port            "$PORT" \
         --argjson  volume          "$VOLUME" \
-        --argjson  wait            "$WAIT_SECS" \
+        --argjson  wait             "$WAIT_SECS" \
         --argjson  skip_restore    "$SKIP_RESTORE" \
         --argjson  lat             "$LATITUDE" \
         --argjson  lon             "$LONGITUDE" \
         --arg      tz              "$TIMEZONE" \
         --argjson  offset          "$SUNSET_OFFSET" \
         --argjson  schedules       "$SCHEDULES_JSON" \
+        --argjson  paused          "$PAUSED_PRESERVED" \
+        --arg      paused_until    "$PAUSED_UNTIL_PRESERVED" \
         '{
           "speakers":              $speakers,
           "port":                  $port,
@@ -740,7 +749,9 @@ function configure_setup() {
           "longitude":             $lon,
           "timezone":              $tz,
           "sunset_offset_minutes": $offset,
-          "schedules":             $schedules
+          "schedules":             $schedules,
+          "paused":                $paused,
+          "paused_until":          $paused_until
         }' > "$CONFIG_FILE"
     log "✅ config.json written."
 }
@@ -1105,6 +1116,176 @@ function _msp_pick_file() {
     done
     echo "  ⚠️  '$_finput' not found in $AUDIO_DIR."
     return 1
+}
+
+# ---------------------------------------------------------------------------
+# Read pause state from config.json and populate three globals:
+#   _PAUSE_FLAG:       "true" / "false" / "" (empty when config.json missing)
+#   _PAUSE_UNTIL:      "" or "YYYY-MM-DD"
+#   _PAUSE_DESC:       human-readable description used by the menu header and
+#                      the pause/resume sub-menu (empty when not paused)
+# Auto-resume detection (paused_until elapsed) is NOT done here — that is the
+# job of schedule_sonos.py during the daily reschedule run.  This helper only
+# reflects what is currently written in config.json.
+# ---------------------------------------------------------------------------
+function _pause_status() {
+    _PAUSE_FLAG=""
+    _PAUSE_UNTIL=""
+    _PAUSE_DESC=""
+    if [ ! -f "$CONFIG_FILE" ] || ! command -v jq &>/dev/null; then
+        return
+    fi
+    _PAUSE_FLAG=$(jq -r '.paused // false' "$CONFIG_FILE" 2>/dev/null || echo "false")
+    _PAUSE_UNTIL=$(jq -r '.paused_until // ""' "$CONFIG_FILE" 2>/dev/null || echo "")
+    if [ "$_PAUSE_FLAG" = "true" ]; then
+        if [[ "$_PAUSE_UNTIL" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            # Resume the day after paused_until (inclusive end-of-vacation day)
+            local _resume_date
+            _resume_date=$(date -d "$_PAUSE_UNTIL +1 day" +%Y-%m-%d 2>/dev/null || echo "")
+            if [ -n "$_resume_date" ]; then
+                _PAUSE_DESC="⏸️  Paused (resumes ${_resume_date})"
+            else
+                _PAUSE_DESC="⏸️  Paused (until ${_PAUSE_UNTIL})"
+            fi
+        else
+            _PAUSE_DESC="⏸️  Paused indefinitely"
+        fi
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Interactive screen for option ${MENU_PAUSE}.  When not paused, prompts for a
+# resume date (or indefinite) and sets paused=true in config.json.  When
+# already paused, offers to resume immediately.  After the config.json edit,
+# re-runs schedule_sonos.py so the systemd timers are disabled (pause) or
+# re-enabled (resume) right away.
+# ---------------------------------------------------------------------------
+function pause_resume_plays() {
+    echo ""
+    echo "============================================"
+    echo "  Pause / Resume Scheduled Plays"
+    echo "============================================"
+
+    if [ ! -f "$CONFIG_FILE" ]; then
+        echo "  ⚠️  config.json not found. Please run Install (option ${MENU_INSTALL}) first."
+        echo ""
+        read -rp "  Press Enter to return to menu..." _pause
+        return
+    fi
+    if ! command -v jq &>/dev/null; then
+        echo "  ⚠️  'jq' not found. Cannot edit config.json."
+        echo ""
+        read -rp "  Press Enter to return to menu..." _pause
+        return
+    fi
+
+    _pause_status
+
+    local _new_paused=""
+    local _new_until=""
+
+    if [ "$_PAUSE_FLAG" = "true" ]; then
+        echo "  Current state: $_PAUSE_DESC"
+        echo ""
+        read -rp "  Resume scheduled plays now? [Y/n]: " _pr_resume
+        if [[ "${_pr_resume,,}" == "n" ]]; then
+            echo "  No change."
+            echo ""
+            read -rp "  Press Enter to return to menu..." _pause
+            return
+        fi
+        _new_paused="false"
+        _new_until=""
+    else
+        echo "  Scheduled plays are currently active."
+        echo ""
+        echo "  How long should they be paused?"
+        echo "    1) Until a specific date (e.g. last day of vacation)"
+        echo "    2) Indefinitely (resume manually later)"
+        echo "    3) Cancel"
+        echo ""
+        read -rp "  Enter your choice [1-3]: " _pr_choice
+        case "$_pr_choice" in
+            1)
+                local _today
+                _today=$(date +%Y-%m-%d)
+                while true; do
+                    read -rp "  Last paused day (YYYY-MM-DD, e.g. last day of vacation): " _pr_date
+                    if [[ ! "$_pr_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                        echo "  ⚠️  Invalid format. Use YYYY-MM-DD."
+                        continue
+                    fi
+                    # Validate it parses as a real date and is not in the past
+                    if ! date -d "$_pr_date" +%Y-%m-%d &>/dev/null; then
+                        echo "  ⚠️  '$_pr_date' is not a valid calendar date."
+                        continue
+                    fi
+                    if [[ "$_pr_date" < "$_today" ]]; then
+                        echo "  ⚠️  '$_pr_date' is in the past. Pick today or a future date."
+                        continue
+                    fi
+                    break
+                done
+                local _resume_on
+                _resume_on=$(date -d "$_pr_date +1 day" +%Y-%m-%d 2>/dev/null || echo "$_pr_date")
+                echo ""
+                echo "  Plays will be silenced through ${_pr_date} and resume on ${_resume_on}."
+                read -rp "  Confirm? [Y/n]: " _pr_confirm
+                if [[ "${_pr_confirm,,}" == "n" ]]; then
+                    echo "  Cancelled."
+                    echo ""
+                    read -rp "  Press Enter to return to menu..." _pause
+                    return
+                fi
+                _new_paused="true"
+                _new_until="$_pr_date"
+                ;;
+            2)
+                echo ""
+                read -rp "  Pause indefinitely (use option ${MENU_PAUSE} to resume)? [Y/n]: " _pr_confirm
+                if [[ "${_pr_confirm,,}" == "n" ]]; then
+                    echo "  Cancelled."
+                    echo ""
+                    read -rp "  Press Enter to return to menu..." _pause
+                    return
+                fi
+                _new_paused="true"
+                _new_until=""
+                ;;
+            *)
+                echo "  Cancelled."
+                echo ""
+                read -rp "  Press Enter to return to menu..." _pause
+                return
+                ;;
+        esac
+    fi
+
+    # Atomically update only .paused / .paused_until in config.json
+    jq --argjson paused "$_new_paused" --arg until "$_new_until" \
+        '.paused = $paused | .paused_until = $until' \
+        "$CONFIG_FILE" > "${CONFIG_FILE}.tmp" \
+        && mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
+
+    if [ "$_new_paused" = "true" ]; then
+        if [ -n "$_new_until" ]; then
+            log "⏸️  Scheduled plays paused (resumes $(date -d "$_new_until +1 day" +%Y-%m-%d 2>/dev/null || echo "after $_new_until"))."
+        else
+            log "⏸️  Scheduled plays paused indefinitely."
+        fi
+    else
+        log "▶️  Scheduled plays resumed."
+    fi
+
+    if [ -d "$VENV_DIR" ]; then
+        log "🗓️  Applying change to systemd timer units..."
+        maybe_sudo "$VENV_DIR/bin/python" "$INSTALL_DIR/schedule_sonos.py"
+    else
+        log "⚠️  Python venv not found. Run option ${MENU_INSTALL} (Install) to (re)create timers."
+    fi
+
+    echo ""
+    read -rp "  Press Enter to return to menu..." _pause
 }
 
 # ---------------------------------------------------------------------------
@@ -1566,6 +1747,9 @@ function prompt_menu() {
     get_sunset_header_line || true
     [ -n "$SUNSET_HEADER_LINE" ] && echo "$SUNSET_HEADER_LINE" || true
 
+    _pause_status
+    [ -n "$_PAUSE_DESC" ] && echo "  Pause:   $_PAUSE_DESC" || true
+
     if [ "$INSTALL_STATE" != "installed" ]; then
         echo ""
         echo "  ============================================"
@@ -1583,6 +1767,10 @@ function prompt_menu() {
     local _reconfig_label="Reconfigure (edit config.json interactively)"
     local _reload_label="Reload config (apply config.json changes)"
     local _manage_label="Manage scheduled plays (add / edit / remove)"
+    local _pause_label="Pause scheduled plays (vacation mode)"
+    if [ "$_PAUSE_FLAG" = "true" ]; then
+        _pause_label="Resume scheduled plays"
+    fi
 
     if [ "$INSTALL_STATE" = "none" ] || [ "$INSTALL_STATE" = "partial_no_venv" ]; then
         _install_label="Install (first-time setup)  ← start here"
@@ -1593,6 +1781,7 @@ function prompt_menu() {
         _upgrade_label="Upgrade (update scripts, keep config)  (requires install)"
         _reload_label="Reload config (apply config.json changes)  (requires install)"
         _manage_label="Manage scheduled plays (add / edit / remove)  (requires install)"
+        _pause_label="Pause / Resume scheduled plays  (requires install)"
     fi
 
     if [ "$INSTALL_STATE" = "none" ]; then
@@ -1612,13 +1801,14 @@ function prompt_menu() {
     echo "  7) $_reconfig_label"
     echo "  8) $_reload_label"
     echo "  9) $_manage_label"
+    echo "  10) $_pause_label"
     echo ""
     echo "  ── Danger zone ────────────────────────"
-    echo "  10) Uninstall completely"
+    echo "  11) Uninstall completely"
     echo ""
-    echo "  11) Exit without doing anything"
+    echo "  12) Exit without doing anything"
     echo ""
-    read -rp "Enter your choice [1-11]: " CHOICE
+    read -rp "Enter your choice [1-12]: " CHOICE
 }
 
 # ---------------------------------------------------------------------------
@@ -2323,6 +2513,10 @@ while true; do
         "$MENU_MANAGE")
             _require_install || continue
             manage_scheduled_plays
+            ;;
+        "$MENU_PAUSE")
+            _require_install || continue
+            pause_resume_plays
             ;;
         "$MENU_UNINSTALL")
             uninstall_all

--- a/tests/test_menu_render.sh
+++ b/tests/test_menu_render.sh
@@ -2,8 +2,8 @@
 # tests/test_menu_render.sh — Smoke test for setup.sh menu structure.
 #
 # Static checks that catch the regression class behind PR #67:
-#   - The main menu has exactly 11 numbered options, in order 1..11.
-#   - The MENU_* constants are sequential 1..11 and dispatched in the case loop.
+#   - The main menu has exactly 12 numbered options, in order 1..12.
+#   - The MENU_* constants are sequential 1..12 and dispatched in the case loop.
 #   - No cron-backend identifiers leaked back into setup.sh.
 #   - setup.sh parses with `bash -n`.
 #
@@ -39,48 +39,48 @@ if [[ -z "$menu_body" ]]; then
     exit 1
 fi
 
-# 1. Exactly 11 numbered options inside prompt_menu
+# 1. Exactly 12 numbered options inside prompt_menu
 option_count=$(printf '%s\n' "$menu_body" \
     | grep -cE '^[[:space:]]+echo[[:space:]]+"[[:space:]]+[0-9]+\)' || true)
-if [[ "$option_count" == "11" ]]; then
-    pass "Menu has 11 numbered options"
+if [[ "$option_count" == "12" ]]; then
+    pass "Menu has 12 numbered options"
 else
-    fail "Menu has $option_count numbered options (expected 11)"
+    fail "Menu has $option_count numbered options (expected 12)"
 fi
 
-# 2. Numbers are 1..11 in order
+# 2. Numbers are 1..12 in order
 nums=$(printf '%s\n' "$menu_body" \
     | grep -oE '"[[:space:]]+[0-9]+\)' \
     | grep -oE '[0-9]+')
-expected_nums=$(seq 1 11)
+expected_nums=$(seq 1 12)
 if [[ "$nums" == "$expected_nums" ]]; then
-    pass "Options numbered 1..11 in order"
+    pass "Options numbered 1..12 in order"
 else
-    fail "Numbering wrong: got '$(echo "$nums" | tr '\n' ' ')', expected 1..11"
+    fail "Numbering wrong: got '$(echo "$nums" | tr '\n' ' ')', expected 1..12"
 fi
 
-# 3. Final read prompt advertises [1-11]
-if grep -qE 'Enter your choice \[1-11\]' "$SETUP_SH"; then
-    pass "Final read prompt is [1-11]"
+# 3. Final read prompt advertises [1-12]
+if grep -qE 'Enter your choice \[1-12\]' "$SETUP_SH"; then
+    pass "Final read prompt is [1-12]"
 else
-    fail "Final read prompt does not say [1-11]"
+    fail "Final read prompt does not say [1-12]"
 fi
 
-# 4. MENU_* constants: sequential 1..11, no MENU_BACKEND
+# 4. MENU_* constants: sequential 1..12, no MENU_BACKEND
 constants=$(grep -E '^readonly MENU_[A-Z]+=[0-9]+$' "$SETUP_SH")
 const_count=$(printf '%s\n' "$constants" | wc -l | tr -d ' ')
-if [[ "$const_count" == "11" ]]; then
-    pass "11 MENU_* constants defined"
+if [[ "$const_count" == "12" ]]; then
+    pass "12 MENU_* constants defined"
 else
-    fail "$const_count MENU_* constants defined (expected 11)"
+    fail "$const_count MENU_* constants defined (expected 12)"
 fi
 
 const_values=$(printf '%s\n' "$constants" | grep -oE '=[0-9]+$' | tr -d '=' | sort -n)
-expected_values=$(seq 1 11)
+expected_values=$(seq 1 12)
 if [[ "$const_values" == "$expected_values" ]]; then
-    pass "MENU_* values are 1..11"
+    pass "MENU_* values are 1..12"
 else
-    fail "MENU_* values not 1..11: got '$(echo "$const_values" | tr '\n' ' ')'"
+    fail "MENU_* values not 1..12: got '$(echo "$const_values" | tr '\n' ' ')'"
 fi
 
 if grep -qE '^readonly MENU_BACKEND=' "$SETUP_SH"; then


### PR DESCRIPTION
## Summary

- Adds menu option **10) Pause / Resume scheduled plays** to `setup.sh` so the user can silence all bugle calls while away from home without uninstalling. The label flips between "Pause" and "Resume" based on current state, and the menu header shows e.g. `Pause: ⏸️  Paused (resumes 2026-05-06)`.
- Stores pause state in `config.json` as `paused` (bool) and `paused_until` (`""` = indefinite, `"YYYY-MM-DD"` = inclusive last paused day). State survives `Reconfigure` and the daily reschedule cycle.
- `schedule_sonos.py` auto-resumes the morning after `paused_until`: atomically rewrites `config.json` (preserving all other keys and file ownership where supported) and re-enables timers via the normal first-install path.

## How pause is enforced

While paused, `schedule_sonos.py`:
- Writes/refreshes the unit files normally so a future resume just re-enables them.
- Disables every active `flag-{name}.timer` (skipping reserved units `flag-audio-http`, `flag-reschedule`, `flag-boot-reschedule`).
- **Keeps `flag-reschedule.timer` and `flag-boot-reschedule.service` enabled** so the daily 02:00 check and post-boot recovery can re-evaluate `paused_until` and auto-resume — even across reboots during a multi-week vacation.

## Why this design (Option A from the plan discussion)

Stopping the systemd units alone would have worked for one cycle, but the daily reschedule run would re-enable them. Putting the state in config.json keeps it the source of truth, gives the menu header a clear status indicator, and lets `paused_until` auto-resume on the right day with zero further user action.

## Files changed

- `setup.sh` — new `_pause_status` / `pause_resume_plays` functions, menu wiring (12 options now), reconfigure preserves pause state.
- `schedule_sonos.py` — `_resolve_pause_state`, `_clear_pause_in_config`, `_disable_active_schedule_timers`, and a paused-mode branch in `main()`.
- `tests/test_menu_render.sh` — bumped expectations from 11 → 12 options.

## Test plan

- [x] `bash -n setup.sh`
- [x] `python -m py_compile schedule_sonos.py`
- [x] `bash tests/test_menu_render.sh` — 24/24 assertions pass
- [x] Pause-state unit checks (executed inline): not-paused, indefinite, future date (still paused), elapsed → auto-resume + config rewrite preserves other keys, garbage `paused_until` → treated as indefinite, `today == paused_until` → still paused (resumes tomorrow)
- [ ] On a real install: pause until tomorrow, verify `systemctl list-timers --all | grep flag` shows schedule timers inactive while `flag-reschedule.timer` remains enabled
- [ ] On a real install: set `paused_until` to yesterday, run `sudo /opt/flag/sonos-env/bin/python /opt/flag/schedule_sonos.py`, verify auto-resume rewrites `config.json` and re-enables timers
- [ ] Walk through the menu: pause → confirm header shows `⏸️  Paused (resumes …)`; resume → confirm header line disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)