### PR TITLE
Add menu option to change Sonos volume (global + per-speaker)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -20,8 +20,9 @@ readonly MENU_UPGRADE=6
 readonly MENU_RECONFIG=7
 readonly MENU_RELOAD=8
 readonly MENU_MANAGE=9
-readonly MENU_UNINSTALL=10
-readonly MENU_EXIT=11
+readonly MENU_VOLUME=10
+readonly MENU_UNINSTALL=11
+readonly MENU_EXIT=12
 
 # ---------------------------------------------------------------------------
 # Table of contents
@@ -33,6 +34,7 @@ readonly MENU_EXIT=11
 #   Sunset:          show_sunset_time, get_sunset_header_line
 #   Status:          test_sonos_playback, list_scheduled_plays, view_logs
 #   Manage plays:    _msp_valid_time, _msp_pick_file, manage_scheduled_plays
+#   Manage volume:   manage_volume
 #   Install state:   detect_install_state, show_install_required_msg,
 #                    _require_install, _resolve_speaker_names
 #   Menu:            prompt_menu
@@ -1344,6 +1346,176 @@ function manage_scheduled_plays() {
     done
 }
 
+# ---------------------------------------------------------------------------
+# Quick-edit menu for global default volume and per-speaker volume overrides.
+# Writes only the .volume and .speakers keys back to config.json — no timer
+# regeneration, no service restart, since sonos_play.py reads volume at
+# playback time.
+# ---------------------------------------------------------------------------
+function manage_volume() {
+    echo ""
+    echo "============================================"
+    echo "  Manage Volume"
+    echo "============================================"
+
+    if [ ! -f "$CONFIG_FILE" ]; then
+        echo "  ⚠️  config.json not found. Please run Install first."
+        return
+    fi
+    if ! command -v jq &>/dev/null; then
+        echo "  ⚠️  'jq' not found. Cannot manage volume."
+        return
+    fi
+
+    # Load current values into globals so the sub-menu can mutate them.
+    local _global_vol
+    _global_vol=$(jq -r '.volume // 30' "$CONFIG_FILE")
+
+    _mvips=(); _mvnames=(); _mvvols=(); _mvcount=0
+    local _spk_count
+    _spk_count=$(jq '.speakers | length // 0' "$CONFIG_FILE" 2>/dev/null || echo "0")
+    for (( _i=0; _i<_spk_count; _i++ )); do
+        _mvips[$_mvcount]=$(jq -r ".speakers[${_i}].ip // \"\"" "$CONFIG_FILE")
+        _mvnames[$_mvcount]=$(jq -r ".speakers[${_i}].name // \"\"" "$CONFIG_FILE")
+        # Empty string sentinel = no override (use global default).
+        _mvvols[$_mvcount]=$(jq -r "if .speakers[${_i}] | has(\"volume\") then (.speakers[${_i}].volume | tostring) else \"\" end" "$CONFIG_FILE")
+        _mvcount=$(( _mvcount + 1 ))
+    done
+
+    while true; do
+        echo ""
+        echo "  Current volume settings:"
+        echo "    Global default: $_global_vol"
+        if [ "$_mvcount" -eq 0 ]; then
+            echo "    (no speakers configured)"
+        else
+            for (( _j=0; _j<_mvcount; _j++ )); do
+                local _label
+                if [ -n "${_mvnames[$_j]}" ]; then
+                    _label="\"${_mvnames[$_j]}\" (${_mvips[$_j]})"
+                else
+                    _label="${_mvips[$_j]}"
+                fi
+                if [ -n "${_mvvols[$_j]}" ]; then
+                    printf "    %d. %s: %s  (override)\n" "$(( _j + 1 ))" "$_label" "${_mvvols[$_j]}"
+                else
+                    printf "    %d. %s: %s  (default)\n" "$(( _j + 1 ))" "$_label" "$_global_vol"
+                fi
+            done
+        fi
+
+        echo ""
+        echo "  ── Manage Volume ──────────────────────────────────────"
+        echo "  1) Edit global default volume"
+        echo "  2) Set/edit per-speaker volume override"
+        echo "  3) Clear per-speaker override (use global default)"
+        echo "  4) Save and apply changes"
+        echo "  5) Cancel without saving"
+        echo ""
+        read -rp "  Enter your choice [1-5]: " _vol_choice
+
+        case "$_vol_choice" in
+            1)
+                # ── Edit global default ──
+                while true; do
+                    read -rp "  New global default volume 0–100 [${_global_vol}]: " _new_vol
+                    _new_vol="${_new_vol:-$_global_vol}"
+                    if [[ "$_new_vol" =~ ^[0-9]+$ ]] && [ "$_new_vol" -ge 0 ] && [ "$_new_vol" -le 100 ]; then
+                        _global_vol="$_new_vol"
+                        echo "  ✅ Global default set to $_global_vol."
+                        break
+                    fi
+                    echo "  ⚠️  Please enter a number between 0 and 100."
+                done
+                ;;
+            2)
+                # ── Set/edit per-speaker override ──
+                if [ "$_mvcount" -eq 0 ]; then
+                    echo "  (no speakers to override)"
+                    continue
+                fi
+                read -rp "  Speaker number (1-${_mvcount}, 0 to cancel): " _spk_idx
+                if [ "$_spk_idx" = "0" ] || [ -z "$_spk_idx" ]; then
+                    echo "  Cancelled."
+                    continue
+                fi
+                if ! [[ "$_spk_idx" =~ ^[0-9]+$ ]] || [ "$_spk_idx" -lt 1 ] || [ "$_spk_idx" -gt "$_mvcount" ]; then
+                    echo "  ⚠️  Invalid selection."
+                    continue
+                fi
+                local _si=$(( _spk_idx - 1 ))
+                local _cur="${_mvvols[$_si]:-$_global_vol}"
+                while true; do
+                    read -rp "  Volume override 0–100 [${_cur}]: " _new
+                    _new="${_new:-$_cur}"
+                    if [[ "$_new" =~ ^[0-9]+$ ]] && [ "$_new" -ge 0 ] && [ "$_new" -le 100 ]; then
+                        _mvvols[$_si]="$_new"
+                        echo "  ✅ Override set to $_new."
+                        break
+                    fi
+                    echo "  ⚠️  Please enter a number between 0 and 100."
+                done
+                ;;
+            3)
+                # ── Clear per-speaker override ──
+                if [ "$_mvcount" -eq 0 ]; then
+                    echo "  (no speakers to clear)"
+                    continue
+                fi
+                read -rp "  Speaker number to clear (1-${_mvcount}, 0 to cancel): " _spk_idx
+                if [ "$_spk_idx" = "0" ] || [ -z "$_spk_idx" ]; then
+                    echo "  Cancelled."
+                    continue
+                fi
+                if ! [[ "$_spk_idx" =~ ^[0-9]+$ ]] || [ "$_spk_idx" -lt 1 ] || [ "$_spk_idx" -gt "$_mvcount" ]; then
+                    echo "  ⚠️  Invalid selection."
+                    continue
+                fi
+                local _si=$(( _spk_idx - 1 ))
+                _mvvols[$_si]=""
+                echo "  ✅ Override cleared (will use global default)."
+                ;;
+            4)
+                # ── Save and apply ──
+                # Walk the existing speakers array by index to preserve every
+                # field (name, ip, anything else) and only touch .volume.
+                local _new_speakers="[]"
+                for (( _i=0; _i<_mvcount; _i++ )); do
+                    local _existing
+                    _existing=$(jq ".speakers[${_i}]" "$CONFIG_FILE")
+                    if [ -n "${_mvvols[$_i]}" ]; then
+                        _new_speakers=$(echo "$_new_speakers" | jq \
+                            --argjson obj "$_existing" \
+                            --argjson vol "${_mvvols[$_i]}" \
+                            '. + [$obj + {volume: $vol}]')
+                    else
+                        _new_speakers=$(echo "$_new_speakers" | jq \
+                            --argjson obj "$_existing" \
+                            '. + [$obj | del(.volume)]')
+                    fi
+                done
+                jq --argjson vol "$_global_vol" --argjson speakers "$_new_speakers" \
+                    '.volume = $vol | .speakers = $speakers' \
+                    "$CONFIG_FILE" > "${CONFIG_FILE}.tmp" \
+                    && mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
+                log "✅ Volume settings saved to config.json."
+                echo "  ℹ️  Changes take effect at the next scheduled or test playback."
+                echo ""
+                read -rp "  Press Enter to return to menu..." _pause
+                return
+                ;;
+            5|"")
+                # ── Cancel ──
+                echo "  ↩️  Changes discarded."
+                return
+                ;;
+            *)
+                echo "  ⚠️  Invalid choice. Enter 1–5."
+                ;;
+        esac
+    done
+}
+
 function view_logs() {
     # Shows the last 20 lines of both setup.log and sonos_play.log side by side,
     # each prefixed with a section heading so recent activity is easy to scan.
@@ -1583,6 +1755,7 @@ function prompt_menu() {
     local _reconfig_label="Reconfigure (edit config.json interactively)"
     local _reload_label="Reload config (apply config.json changes)"
     local _manage_label="Manage scheduled plays (add / edit / remove)"
+    local _volume_label="Manage volume (global default + per-speaker overrides)"
 
     if [ "$INSTALL_STATE" = "none" ] || [ "$INSTALL_STATE" = "partial_no_venv" ]; then
         _install_label="Install (first-time setup)  ← start here"
@@ -1597,6 +1770,7 @@ function prompt_menu() {
 
     if [ "$INSTALL_STATE" = "none" ]; then
         _reconfig_label="Reconfigure (edit config.json interactively)  (requires install)"
+        _volume_label="Manage volume (global default + per-speaker overrides)  (requires install)"
     fi
 
     echo ""
@@ -1612,13 +1786,14 @@ function prompt_menu() {
     echo "  7) $_reconfig_label"
     echo "  8) $_reload_label"
     echo "  9) $_manage_label"
+    echo "  10) $_volume_label"
     echo ""
     echo "  ── Danger zone ────────────────────────"
-    echo "  10) Uninstall completely"
+    echo "  11) Uninstall completely"
     echo ""
-    echo "  11) Exit without doing anything"
+    echo "  12) Exit without doing anything"
     echo ""
-    read -rp "Enter your choice [1-11]: " CHOICE
+    read -rp "Enter your choice [1-12]: " CHOICE
 }
 
 # ---------------------------------------------------------------------------
@@ -2323,6 +2498,13 @@ while true; do
         "$MENU_MANAGE")
             _require_install || continue
             manage_scheduled_plays
+            ;;
+        "$MENU_VOLUME")
+            if [ "$INSTALL_STATE" = "none" ]; then
+                show_install_required_msg
+            else
+                manage_volume
+            fi
             ;;
         "$MENU_UNINSTALL")
             uninstall_all

--- a/tests/test_menu_render.sh
+++ b/tests/test_menu_render.sh
@@ -2,8 +2,8 @@
 # tests/test_menu_render.sh — Smoke test for setup.sh menu structure.
 #
 # Static checks that catch the regression class behind PR #67:
-#   - The main menu has exactly 11 numbered options, in order 1..11.
-#   - The MENU_* constants are sequential 1..11 and dispatched in the case loop.
+#   - The main menu has exactly 12 numbered options, in order 1..12.
+#   - The MENU_* constants are sequential 1..12 and dispatched in the case loop.
 #   - No cron-backend identifiers leaked back into setup.sh.
 #   - setup.sh parses with `bash -n`.
 #
@@ -39,48 +39,48 @@ if [[ -z "$menu_body" ]]; then
     exit 1
 fi
 
-# 1. Exactly 11 numbered options inside prompt_menu
+# 1. Exactly 12 numbered options inside prompt_menu
 option_count=$(printf '%s\n' "$menu_body" \
     | grep -cE '^[[:space:]]+echo[[:space:]]+"[[:space:]]+[0-9]+\)' || true)
-if [[ "$option_count" == "11" ]]; then
-    pass "Menu has 11 numbered options"
+if [[ "$option_count" == "12" ]]; then
+    pass "Menu has 12 numbered options"
 else
     fail "Menu has $option_count numbered options (expected 11)"
 fi
 
-# 2. Numbers are 1..11 in order
+# 2. Numbers are 1..12 in order
 nums=$(printf '%s\n' "$menu_body" \
     | grep -oE '"[[:space:]]+[0-9]+\)' \
     | grep -oE '[0-9]+')
-expected_nums=$(seq 1 11)
+expected_nums=$(seq 1 12)
 if [[ "$nums" == "$expected_nums" ]]; then
-    pass "Options numbered 1..11 in order"
+    pass "Options numbered 1..12 in order"
 else
-    fail "Numbering wrong: got '$(echo "$nums" | tr '\n' ' ')', expected 1..11"
+    fail "Numbering wrong: got '$(echo "$nums" | tr '\n' ' ')', expected 1..12"
 fi
 
-# 3. Final read prompt advertises [1-11]
-if grep -qE 'Enter your choice \[1-11\]' "$SETUP_SH"; then
-    pass "Final read prompt is [1-11]"
+# 3. Final read prompt advertises [1-12]
+if grep -qE 'Enter your choice \[1-12\]' "$SETUP_SH"; then
+    pass "Final read prompt is [1-12]"
 else
-    fail "Final read prompt does not say [1-11]"
+    fail "Final read prompt does not say [1-12]"
 fi
 
-# 4. MENU_* constants: sequential 1..11, no MENU_BACKEND
+# 4. MENU_* constants: sequential 1..12, no MENU_BACKEND
 constants=$(grep -E '^readonly MENU_[A-Z]+=[0-9]+$' "$SETUP_SH")
 const_count=$(printf '%s\n' "$constants" | wc -l | tr -d ' ')
-if [[ "$const_count" == "11" ]]; then
-    pass "11 MENU_* constants defined"
+if [[ "$const_count" == "12" ]]; then
+    pass "12 MENU_* constants defined"
 else
-    fail "$const_count MENU_* constants defined (expected 11)"
+    fail "$const_count MENU_* constants defined (expected 12)"
 fi
 
 const_values=$(printf '%s\n' "$constants" | grep -oE '=[0-9]+$' | tr -d '=' | sort -n)
-expected_values=$(seq 1 11)
+expected_values=$(seq 1 12)
 if [[ "$const_values" == "$expected_values" ]]; then
-    pass "MENU_* values are 1..11"
+    pass "MENU_* values are 1..12"
 else
-    fail "MENU_* values not 1..11: got '$(echo "$const_values" | tr '\n' ' ')'"
+    fail "MENU_* values not 1..12: got '$(echo "$const_values" | tr '\n' ' ')'"
 fi
 
 if grep -qE '^readonly MENU_BACKEND=' "$SETUP_SH"; then


### PR DESCRIPTION
## Summary
- New `manage_volume()` function in `setup.sh` adds menu option 10 — a quick-edit sub-menu for the global default volume and per-speaker overrides — so users can adjust volume without rerunning the full Reconfigure wizard.
- Save writes only `.volume` and `.speakers` keys atomically via `jq`; no timer regeneration or service restart, since `sonos_play.py` reads volume at playback time. Changes take effect at the next scheduled or test playback.
- `MENU_VOLUME=10` constant added; Uninstall shifts to 11, Exit to 12. `tests/test_menu_render.sh` updated for the 12-option layout.

## What's in the new sub-menu
1. Edit global default volume
2. Set/edit per-speaker volume override
3. Clear per-speaker override (use global default)
4. Save and apply changes
5. Cancel without saving

The current state (global default + each speaker's effective volume, marked `(override)` or `(default)`) is shown above the prompt on every iteration.

## Notes for reviewers
- Per-speaker save preserves any other fields on the speaker object (name, ip, future fields) by walking the existing `.speakers[]` by index — only `.volume` is added or `del`-ed.
- Gated like Reconfigure (option 7): only the `INSTALL_STATE=none` case shows the "requires install" hint, since volume editing only needs `config.json` + `jq` (no venv, no timers).
- The Manage Volume option is listed under Configuration alongside Manage scheduled plays.

## Test plan
- [x] `bash -n setup.sh` passes
- [x] `bash tests/test_menu_render.sh` — all 24 assertions pass (12-option menu, MENU_VOLUME has dispatch case)
- [ ] Manual: edit global volume, save, confirm `.volume` updated and `.speakers` untouched
- [ ] Manual: set a per-speaker override, save, confirm only that speaker's `.volume` field added
- [ ] Manual: clear an override, save, confirm `.volume` field deleted from that speaker only
- [ ] Manual: cancel discards changes (re-read shows original values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)